### PR TITLE
Controllers placement and client package fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
 						<configuration>
 							<includeGroupIds>mathpar.web.learning</includeGroupIds>
 							<includeArtifactIds>client</includeArtifactIds>
+							<includeTypes>jar</includeTypes>
 							<outputDirectory>
 								${project.build.directory}/classes/assets
 							</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 						</goals>
 						<configuration>
 							<includes>
-								<include>mathpar.client:bundle:jar:*</include>
+								<include>mathpar.web.learning:client:jar:*:*</include>
 							</includes>
 							<serverId>github-mathpar</serverId>
 						</configuration>
@@ -182,8 +182,8 @@
 							<goal>unpack-dependencies</goal>
 						</goals>
 						<configuration>
-							<includeGroupIds>mathpar.client</includeGroupIds>
-							<includeArtifactIds>bundle</includeArtifactIds>
+							<includeGroupIds>mathpar.web.learning</includeGroupIds>
+							<includeArtifactIds>client</includeArtifactIds>
 							<outputDirectory>
 								${project.build.directory}/classes/assets
 							</outputDirectory>

--- a/src/main/java/mathpar/web/learning/gateway/controllers/AccountProxy.java
+++ b/src/main/java/mathpar/web/learning/gateway/controllers/AccountProxy.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.gateway;
+package mathpar.web.learning.gateway.controllers;
 
 import mathpar.web.learning.gateway.utils.MathparProperties;
 import org.springframework.http.RequestEntity;

--- a/src/main/java/mathpar/web/learning/gateway/controllers/DocsController.java
+++ b/src/main/java/mathpar/web/learning/gateway/controllers/DocsController.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.gateway;
+package mathpar.web.learning.gateway.controllers;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +12,7 @@ public class DocsController {
     @GetMapping("/swagger-resources")
     public List<SwaggerResource> getResources(){
         return List.of(
-                new SwaggerResource("Authentication API", "/authentication/docs", "2.0", "/authentication/docs"),
+                new SwaggerResource("Account API", "/account/docs", "2.0", "/account/docs"),
                 new SwaggerResource("School API", "/school/docs", "2.0", "/school/docs")
         );
     }

--- a/src/main/java/mathpar/web/learning/gateway/controllers/IndexController.java
+++ b/src/main/java/mathpar/web/learning/gateway/controllers/IndexController.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.gateway;
+package mathpar.web.learning.gateway.controllers;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/mathpar/web/learning/gateway/controllers/SchoolProxy.java
+++ b/src/main/java/mathpar/web/learning/gateway/controllers/SchoolProxy.java
@@ -1,4 +1,4 @@
-package mathpar.web.learning.gateway;
+package mathpar.web.learning.gateway.controllers;
 
 import mathpar.web.learning.gateway.utils.MathparProperties;
 import org.springframework.http.RequestEntity;


### PR DESCRIPTION
This PR introduces changes to the controllers placement (root package -> controllers package) so they can be picked up by spring (packagesToScan scans all the packages in the gateway package).
Also this PR introduces changes to maven build process to reflect changes introduced to naming of client part of an application